### PR TITLE
If all components of a given type have the same value, aggregate them

### DIFF
--- a/KiCadBomExport.py
+++ b/KiCadBomExport.py
@@ -270,7 +270,8 @@ def processComponent(listOutput, xmlComponent, groupParts):
                 if listItem[fldMfgPartNo] == curPart[fldMfgPartNo] and curPart[fldMfgPartNo] != '-':
                     bDup = True
                     listItem['Reference'] = listItem['Reference'] + ';' + curPart['Reference']  #Add current part reference to the existing part
-                    listItem['Value'] = listItem['Value'] + ';' + curPart['Value']  #Add current part value to the existing part
+                    if listItem['Value'] != curPart['Value']: 
+                        listItem['Value'] = listItem['Value'] + ';' + curPart['Value']  #Add current part value to the existing part
                     listItem['Count'] = str(int(listItem['Count']) + 1) #Increase the count of times this part is used
                     break
 


### PR DESCRIPTION
In just about every case, the value columns in my BOM are a long list of the same value. This pull request stops the tool from building a long, semicolon delimited list if all the values are the same.

The logic is simplistic. If you legitimately have a mixed set of values, you won't get a fully deduped list.
