### PR TITLE
Cleanup README.md syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ This is a simple script process the KiCad intermediate netlist file, and produce
   - Open EESchema
   - TOOLS menu / Generate Bill of Materials
   - Add a new item with a cmd line similar to:
-    python "[path to python script]KiCadBomExport.py" "-i %I" [other cmd line params]
+    ```python "[path to python script]KiCadBomExport.py" "-i %I" [other cmd line params]```
     
-    eg: python "c:\KiCadBomExport.py" -i "%I" -g -f -a xxxxxxxx
+    eg: ```python "c:\KiCadBomExport.py" -i "%I" -g -f -a xxxxxxxx```
     Suggest you don't use the standard "%O" output file parameter, or the .xml output will overwrite the intermediate Netlist file.
 
 ### Usage with SupplyFrame's FindChips API

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Written in Python 2.74, as KiCad seems not to support Python 3
 
 This is a simple script process the KiCad intermediate netlist file, and produce a BOM in both CSV and XML Format
 
-###Features:
+### Features:
 - Optionally groups same components into a single row (cmd line paramater "-g")
 - Optionally costs the BOM using FindChips API (cmd line parameters "-f" and "-a [apikey]")
 - Produces both CSV and XML output
 
-###Command Line Parameters
+### Command Line Parameters
    -h / help   Display Help message
    -g / group  Group like components into a single row
    -i / input  Input file (in KiCad's intermediate XML format)
@@ -18,7 +18,7 @@ This is a simple script process the KiCad intermediate netlist file, and produce
    -a / apikey The API Key from the online costing service
 
 
-###Usage from within KiCad:
+### Usage from within KiCad:
   - Open EESchema
   - TOOLS menu / Generate Bill of Materials
   - Add a new item with a cmd line similar to:
@@ -27,7 +27,7 @@ This is a simple script process the KiCad intermediate netlist file, and produce
     eg: python "c:\KiCadBomExport.py" -i "%I" -g -f -a xxxxxxxx
     Suggest you don't use the standard "%O" output file parameter, or the .xml output will overwrite the intermediate Netlist file.
 
-###Usage with SupplyFrame's FindChips API
+### Usage with SupplyFrame's FindChips API
 You need to request an API from SupplyFrame.  Go to: http://dev.supplyframe.com/
 You will be provided with an API key.  Use this in your command line call after the "-a" argument
 
@@ -36,7 +36,7 @@ Within KiCad EESchema, you will need to define a manufacturer part number:
   - Add "Mfg_Part_No" to store the manufacturer's part number.  Be specific down to package to avoid vague search results
 
 
-###Using the output files
+### Using the output files
 I find that Excel doesn't read the CSV file in well, as it tries to convert data types.
 I prefer to use Excel to open the XML output file:
   - right-click on XML output file, then "open with Excel"
@@ -44,7 +44,7 @@ I prefer to use Excel to open the XML output file:
   - Voila!
 
 
-###Troubleshooting:
+### Troubleshooting:
   - A log file is created in user home directory (eg. on Windows: C:\User\[your username]\Kicad_BOM_Logging.txt)
 
 Further Enhancements Identified:

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ This is a simple script process the KiCad intermediate netlist file, and produce
 - Produces both CSV and XML output
 
 ### Command Line Parameters
-   -h / help   Display Help message
-   -g / group  Group like components into a single row
-   -i / input  Input file (in KiCad's intermediate XML format)
-   -o / output Output file name (will be appended with .CSV and .XML).  If none specified, output file is input file + "_BOM"
-   -f          Use the FindChips API
-   -a / apikey The API Key from the online costing service
+ * ```-h``` / ```-help```   Display Help message
+ * ```-g``` / ```-group```  Group like components into a single row
+ * ```-i``` / ```-input```  Input file (in KiCad's intermediate XML format)
+ * ```-o``` / ```-output``` Output file name (will be appended with .CSV and .XML).  If none specified, output file is input file + "_BOM"
+ * ```-f```           Use the FindChips API
+ * ```-a``` / ```-apikey``` The API Key from the online costing service
 
 
 ### Usage from within KiCad:


### PR DESCRIPTION
Github changed their markdown render to require a space after the ```#``` in headers.

I also added to changes to the command line options and the how to run section to make it more readable.